### PR TITLE
fix: move from repo-name to container-registry

### DIFF
--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -36,7 +36,7 @@ const (
 	appNameFlag           string = "app-name"
 	appVersionFlag        string = "app-version"
 	projectDirectoryFlag  string = "project-directory"
-	repoNameFlag          string = "repo-name"
+	repoNameFlag          string = "container-registry"
 	dockerFileNameFlag    string = "dockerfile-name"
 	configFileFlag        string = "config-file"
 	namespaceFlag         string = "namespace"
@@ -138,10 +138,11 @@ func init() {
 			},
 			&cli.StringFlag{
 				Name:     repoNameFlag,
+				Aliases:  []string{"repo-name"}, // keep compatibility with old version of the config
 				Usage:    "The base address of the container repository",
 				Value:    registry,
 				Required: registry == "",
-				EnvVars:  []string{"INITIUM_REPO_NAME"},
+				EnvVars:  []string{"INITIUM_CONTAINER_REGISTRY", "INITIUM_REPO_NAME"}, // INITIUM_REPO_NAME to keep compatibility with older config
 			},
 			&cli.StringFlag{
 				Name:    dockerFileNameFlag,
@@ -210,12 +211,14 @@ func (c CLI) loadFlagsFromConfig(ctx *cli.Context) error {
 	}
 
 	for _, v := range ctx.Command.Flags {
-		name := v.Names()[0]
-		c.Logger.Debugf("%s is set to %s", name, ctx.String(name))
-		if name != "help" && !ctx.IsSet(name) {
-			if config[name] != nil {
-				c.Logger.Debugf("Loading %s as %s", name, config[name])
-				ctx.Set(name, config[name].(string))
+		mainName := v.Names()[0]
+		for _, name := range v.Names() {
+			c.Logger.Debugf("%s is set to %s", name, ctx.String(name))
+			if name != "help" && !ctx.IsSet(mainName) {
+				if config[name] != nil {
+					c.Logger.Debugf("Loading %s as %s", name, config[name])
+					ctx.Set(mainName, config[name].(string))
+				}
 			}
 		}
 	}

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -139,7 +139,7 @@ func init() {
 			&cli.StringFlag{
 				Name:     repoNameFlag,
 				Aliases:  []string{"repo-name"}, // keep compatibility with old version of the config
-				Usage:    "The base address of the container repository",
+				Usage:    "The base address of the container registry",
 				Value:    registry,
 				Required: registry == "",
 				EnvVars:  []string{"INITIUM_CONTAINER_REGISTRY", "INITIUM_REPO_NAME"}, // INITIUM_REPO_NAME to keep compatibility with older config


### PR DESCRIPTION
repo-name was always confusing, users might think that is a git repo, container registry is a better name but we have to keep retrocompatibility.