### PR TITLE
Feature/get smarter at detecting app name

### DIFF
--- a/src/cli/build.go
+++ b/src/cli/build.go
@@ -18,10 +18,14 @@ func (c *CLI) Build(cCtx *cli.Context) error {
 }
 
 func (c CLI) BuildCMD() *cli.Command {
+	flags := []cli.Flag{}
+	flags = append(flags, c.CommandFlags(Build)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
+
 	return &cli.Command{
 		Name:   "build",
 		Usage:  "build a container image from the project directory",
-		Flags:  c.CommandFlags(Build),
+		Flags:  flags,
 		Action: c.Build,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/build.go
+++ b/src/cli/build.go
@@ -18,14 +18,10 @@ func (c *CLI) Build(cCtx *cli.Context) error {
 }
 
 func (c CLI) BuildCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Build)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
-
 	return &cli.Command{
 		Name:   "build",
 		Usage:  "build a container image from the project directory",
-		Flags:  flags,
+		Flags:  c.CommandFlags([]FlagsType{Build, Shared}),
 		Action: c.Build,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -104,7 +104,7 @@ func (c CLI) Run(args []string) error {
 	app := &cli.App{
 		Name:  "initium",
 		Usage: "CLI of the Initium project",
-		Flags: c.CommandFlags(App),
+		Flags: c.CommandFlags([]FlagsType{App}),
 		Commands: []*cli.Command{
 			c.BuildCMD(),
 			c.PushCMD(),

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -43,6 +43,12 @@ func (c *CLI) init(cCtx *cli.Context) error {
 	version := cCtx.String(appVersionFlag)
 	projectDirectory := cCtx.String(projectDirectoryFlag)
 	absProjectDirectory, err := filepath.Abs(cCtx.String(projectDirectoryFlag))
+	registry := cCtx.String(repoNameFlag)
+	dockerFileName := cCtx.String(dockerFileNameFlag)
+
+	if dockerFileName == "" {
+		dockerFileName = defaults.GeneratedDockerFile
+	}
 
 	if err != nil {
 		c.Logger.Warnf("could not get abs of %s", projectDirectory)
@@ -67,15 +73,10 @@ func (c *CLI) init(cCtx *cli.Context) error {
 	}
 
 	dockerImage := docker.DockerImage{
-		Registry:  cCtx.String(repoNameFlag),
+		Registry:  registry,
 		Name:      dockerImageName,
 		Directory: absProjectDirectory,
 		Tag:       version,
-	}
-
-	dockerFileName := cCtx.String(dockerFileNameFlag)
-	if dockerFileName == "" {
-		dockerFileName = defaults.GeneratedDockerFile
 	}
 
 	dockerService, err := docker.New(project, dockerImage, dockerFileName)

--- a/src/cli/delete.go
+++ b/src/cli/delete.go
@@ -22,10 +22,14 @@ func (c *CLI) Delete(cCtx *cli.Context) error {
 }
 
 func (c *CLI) DeleteCMD() *cli.Command {
+	flags := []cli.Flag{}
+	flags = append(flags, c.CommandFlags(Kubernetes)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
+
 	return &cli.Command{
 		Name:   "delete",
 		Usage:  "delete the knative service",
-		Flags:  c.CommandFlags(Kubernetes),
+		Flags:  flags,
 		Action: c.Delete,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/delete.go
+++ b/src/cli/delete.go
@@ -22,14 +22,10 @@ func (c *CLI) Delete(cCtx *cli.Context) error {
 }
 
 func (c *CLI) DeleteCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Kubernetes)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
-
 	return &cli.Command{
 		Name:   "delete",
 		Usage:  "delete the knative service",
-		Flags:  flags,
+		Flags:  c.CommandFlags([]FlagsType{Kubernetes, Shared}),
 		Action: c.Delete,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/deploy.go
+++ b/src/cli/deploy.go
@@ -24,10 +24,14 @@ func (c *CLI) Deploy(cCtx *cli.Context) error {
 }
 
 func (c CLI) DeployCMD() *cli.Command {
+	flags := []cli.Flag{}
+	flags = append(flags, c.CommandFlags(Kubernetes)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
+
 	return &cli.Command{
 		Name:   "deploy",
 		Usage:  "deploy the application as a knative service",
-		Flags:  c.CommandFlags(Kubernetes),
+		Flags:  flags,
 		Action: c.Deploy,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/deploy.go
+++ b/src/cli/deploy.go
@@ -24,14 +24,10 @@ func (c *CLI) Deploy(cCtx *cli.Context) error {
 }
 
 func (c CLI) DeployCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Kubernetes)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
-
 	return &cli.Command{
 		Name:   "deploy",
 		Usage:  "deploy the application as a knative service",
-		Flags:  flags,
+		Flags:  c.CommandFlags([]FlagsType{Kubernetes, Shared}),
 		Action: c.Deploy,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -23,6 +23,7 @@ const (
 	Registry   FlagsType = "registry"
 	InitGithub FlagsType = "init-github"
 	App        FlagsType = "app"
+	Shared     FlagsType = "shared"
 )
 
 const (
@@ -127,6 +128,20 @@ func init() {
 		},
 		App: []cli.Flag{
 			&cli.StringFlag{
+				Name:    projectDirectoryFlag,
+				Usage:   "The directory in which your Dockerfile lives",
+				Value:   defaults.ProjectDirectory,
+				EnvVars: []string{"INITIUM_PROJECT_DIRECTORY"},
+			},
+			&cli.StringFlag{
+				Name:    configFileFlag,
+				Usage:   "read parameters from config",
+				Value:   defaults.ConfigFile,
+				EnvVars: []string{"INITIUM_CONFIG_FILE"},
+			},
+		},
+		Shared: []cli.Flag{
+			&cli.StringFlag{
 				Name:     appNameFlag,
 				Usage:    "The name of the app",
 				Value:    appName,
@@ -140,12 +155,6 @@ func init() {
 				EnvVars: []string{"INITIUM_VERSION"},
 			},
 			&cli.StringFlag{
-				Name:    projectDirectoryFlag,
-				Usage:   "The directory in which your Dockerfile lives",
-				Value:   defaults.ProjectDirectory,
-				EnvVars: []string{"INITIUM_PROJECT_DIRECTORY"},
-			},
-			&cli.StringFlag{
 				Name:     repoNameFlag,
 				Aliases:  []string{"repo-name"}, // keep compatibility with old version of the config
 				Usage:    "The base address of the container registry",
@@ -157,13 +166,6 @@ func init() {
 				Name:    dockerFileNameFlag,
 				Usage:   "The name of the Dockerfile",
 				EnvVars: []string{"INITIUM_DOCKERFILE_NAME"},
-			},
-			&cli.StringFlag{
-				Name:    configFileFlag,
-				Usage:   "read parameters from config",
-				Hidden:  true,
-				Value:   defaults.ConfigFile,
-				EnvVars: []string{"INITIUM_CONFIG_FILE"},
 			},
 		},
 	}

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nearform/initium-cli/src/services/git"
+	"github.com/nearform/initium-cli/src/services/project"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
@@ -53,6 +54,13 @@ func init() {
 	org, err := git.GetGithubOrg()
 	if err == nil {
 		registry = fmt.Sprintf("ghcr.io/%s", org)
+	}
+
+	appName := ""
+	guess := project.GuessAppName()
+
+	if guess != nil {
+		appName = *guess
 	}
 
 	defaultFlags := map[FlagsType]([]cli.Flag){
@@ -121,7 +129,8 @@ func init() {
 			&cli.StringFlag{
 				Name:     appNameFlag,
 				Usage:    "The name of the app",
-				Required: true,
+				Value:    appName,
+				Required: appName == "",
 				EnvVars:  []string{"INITIUM_APP_NAME"},
 			},
 			&cli.StringFlag{

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -238,6 +238,10 @@ func (c CLI) loadFlagsFromConfig(ctx *cli.Context) error {
 	return nil
 }
 
-func (c CLI) CommandFlags(command FlagsType) []cli.Flag {
-	return flags[command]
+func (c CLI) CommandFlags(commands []FlagsType) []cli.Flag {
+	result := []cli.Flag{}
+	for _, command := range commands {
+		result = append(result, flags[command]...)
+	}
+	return result
 }

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -104,9 +104,13 @@ func (c CLI) InitServiceAccountCMD(ctx *cli.Context) error {
 }
 
 func (c CLI) InitCMD() *cli.Command {
-	githubFlags := []cli.Flag{}
-	githubFlags = append(githubFlags, c.CommandFlags(InitGithub)...)
-	githubFlags = append(githubFlags, c.CommandFlags(Shared)...)
+	configFlags := c.CommandFlags([]FlagsType{Shared})
+	configFlags = append(configFlags, &cli.BoolFlag{
+		Name:  persistFlag,
+		Value: false,
+		Usage: fmt.Sprintf("will write the file content in %s", defaults.ConfigFile),
+	})
+
 	return &cli.Command{
 		Name:  "init",
 		Usage: "create configuration for the cli [EXPERIMENTAL]",
@@ -114,20 +118,14 @@ func (c CLI) InitCMD() *cli.Command {
 			{
 				Name:   "github",
 				Usage:  "create a github pipeline yaml file",
-				Flags:  githubFlags,
+				Flags:  c.CommandFlags([]FlagsType{InitGithub, Shared}),
 				Action: c.InitGithubCMD,
 				Before: c.baseBeforeFunc,
 			},
 			{
-				Name:  "config",
-				Usage: "create a config file with all available flags set to null",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:  persistFlag,
-						Value: false,
-						Usage: fmt.Sprintf("will write the file content in %s", defaults.ConfigFile),
-					},
-				},
+				Name:   "config",
+				Usage:  "create a config file with all available flags set to null",
+				Flags:  configFlags,
 				Action: c.InitConfigCMD,
 				Before: c.baseBeforeFunc,
 			},

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -104,6 +104,9 @@ func (c CLI) InitServiceAccountCMD(ctx *cli.Context) error {
 }
 
 func (c CLI) InitCMD() *cli.Command {
+	githubFlags := []cli.Flag{}
+	githubFlags = append(githubFlags, c.CommandFlags(InitGithub)...)
+	githubFlags = append(githubFlags, c.CommandFlags(Shared)...)
 	return &cli.Command{
 		Name:  "init",
 		Usage: "create configuration for the cli [EXPERIMENTAL]",
@@ -111,7 +114,7 @@ func (c CLI) InitCMD() *cli.Command {
 			{
 				Name:   "github",
 				Usage:  "create a github pipeline yaml file",
-				Flags:  c.CommandFlags(InitGithub),
+				Flags:  githubFlags,
 				Action: c.InitGithubCMD,
 				Before: c.baseBeforeFunc,
 			},

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -75,7 +75,7 @@ func TestInitConfig(t *testing.T) {
 
 	// Command line argument wins over config and Environment variable
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "--app-name=FromParam", "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config", "--app-name=FromParam"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromParam", registry, cli.Writer)

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -98,14 +98,14 @@ func TestRepoNameRetrocompatibiliy(t *testing.T) {
 	}
 
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "--app-name=FromParam", "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config", "--app-name=FromParam"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromParam", "FromFile", cli.Writer)
 
 	//Override from parameter
 	cli.Writer = new(bytes.Buffer)
-	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "--app-name=FromParam", "--container-registry=ghcr.io/nearform", "init", "config"}); err != nil {
+	if err = cli.Run([]string{"initium", fmt.Sprintf("--config-file=%s", f.Name()), "init", "config", "--app-name=FromParam", "--container-registry=ghcr.io/nearform"}); err != nil {
 		t.Error(err)
 	}
 	compareConfig(t, "FromParam", "ghcr.io/nearform", cli.Writer)

--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -33,6 +33,8 @@ func (c CLI) OnBranchCMD() *cli.Command {
 	flags = append(flags, c.CommandFlags(Kubernetes)...)
 	flags = append(flags, c.CommandFlags(Build)...)
 	flags = append(flags, c.CommandFlags(Registry)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
+
 	flags = append(flags, []cli.Flag{
 		&cli.BoolFlag{
 			Name:  stopOnBuildFlag,

--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -29,11 +29,12 @@ func (c CLI) buildPushDeploy(cCtx *cli.Context) error {
 }
 
 func (c CLI) OnBranchCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Kubernetes)...)
-	flags = append(flags, c.CommandFlags(Build)...)
-	flags = append(flags, c.CommandFlags(Registry)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
+	flags := c.CommandFlags([]FlagsType{
+		Kubernetes,
+		Build,
+		Registry,
+		Shared,
+	})
 
 	flags = append(flags, []cli.Flag{
 		&cli.BoolFlag{

--- a/src/cli/onmain.go
+++ b/src/cli/onmain.go
@@ -10,6 +10,7 @@ func (c *CLI) OnMainCMD() *cli.Command {
 	flags = append(flags, c.CommandFlags(Kubernetes)...)
 	flags = append(flags, c.CommandFlags(Build)...)
 	flags = append(flags, c.CommandFlags(Registry)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
 	flags = append(flags, []cli.Flag{
 		&cli.BoolFlag{
 			Name:  stopOnBuildFlag,
@@ -20,6 +21,7 @@ func (c *CLI) OnMainCMD() *cli.Command {
 			Value: false,
 		},
 	}...)
+
 	return &cli.Command{
 		Name:   "onmain",
 		Usage:  "deploy the application as a knative service",

--- a/src/cli/onmain.go
+++ b/src/cli/onmain.go
@@ -6,11 +6,12 @@ import (
 )
 
 func (c *CLI) OnMainCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Kubernetes)...)
-	flags = append(flags, c.CommandFlags(Build)...)
-	flags = append(flags, c.CommandFlags(Registry)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
+	flags := c.CommandFlags([]FlagsType{
+		Kubernetes,
+		Build,
+		Registry,
+		Shared,
+	})
 	flags = append(flags, []cli.Flag{
 		&cli.BoolFlag{
 			Name:  stopOnBuildFlag,

--- a/src/cli/push.go
+++ b/src/cli/push.go
@@ -15,14 +15,10 @@ func (c *CLI) Push(cCtx *cli.Context) error {
 }
 
 func (c *CLI) PushCMD() *cli.Command {
-	flags := []cli.Flag{}
-	flags = append(flags, c.CommandFlags(Registry)...)
-	flags = append(flags, c.CommandFlags(Shared)...)
-
 	return &cli.Command{
 		Name:   "push",
 		Usage:  "push the container image to a registry",
-		Flags:  flags,
+		Flags:  c.CommandFlags([]FlagsType{Registry, Shared}),
 		Action: c.Push,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/push.go
+++ b/src/cli/push.go
@@ -15,10 +15,14 @@ func (c *CLI) Push(cCtx *cli.Context) error {
 }
 
 func (c *CLI) PushCMD() *cli.Command {
+	flags := []cli.Flag{}
+	flags = append(flags, c.CommandFlags(Registry)...)
+	flags = append(flags, c.CommandFlags(Shared)...)
+
 	return &cli.Command{
 		Name:   "push",
 		Usage:  "push the container image to a registry",
-		Flags:  c.CommandFlags(Registry),
+		Flags:  flags,
 		Action: c.Push,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/cli/template.go
+++ b/src/cli/template.go
@@ -23,7 +23,7 @@ func (c *CLI) TemplateCMD() *cli.Command {
 	return &cli.Command{
 		Name:   "template",
 		Usage:  "output the docker file used for this project",
-		Flags:  c.CommandFlags(Build),
+		Flags:  c.CommandFlags([]FlagsType{Build}),
 		Action: c.template,
 		Before: c.baseBeforeFunc,
 	}

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"text/template"
 
+	"github.com/nearform/initium-cli/src/services/git"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 )
 
@@ -34,6 +35,15 @@ type InitOptions struct {
 	Repository        string
 	AppName           string
 	ProjectDirectory  string
+}
+
+func GuessAppName() *string {
+	var name string
+	name, err := git.GetRepoName()
+	if err != nil {
+		return nil
+	}
+	return &name
 }
 
 func New(name string, directory string, runtimeVersion string, version string, resources fs.FS) Project {


### PR DESCRIPTION
The user experience of the CLI wasn't great, not only `app-name` was a mandatory flag but it needed to be specified even for command that were not using it.

This change is an attempt to fix this issue by moving shared to the relevant subcommands.
Major testing is required here!!!