### PR TITLE
chore: onbranch to work with explicit branch name

### DIFF
--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -2,11 +2,15 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
-	git "github.com/go-git/go-git/v5"
+	"github.com/nearform/initium-cli/src/services/git"
 	"github.com/nearform/initium-cli/src/utils"
 	"github.com/urfave/cli/v2"
+)
+
+const (
+	cleanFlag      string = "clean"
+	branchNameFlag string = "branch-name"
 )
 
 func (c icli) buildPushDeploy(cCtx *cli.Context) error {
@@ -40,52 +44,48 @@ func (c icli) OnBranchCMD() *cli.Command {
 		&cli.BoolFlag{
 			Name:  stopOnBuildFlag,
 			Value: false,
+			Usage: "Stop the onbranch command after the build step",
 		},
 		&cli.BoolFlag{
 			Name:  stopOnPushFlag,
 			Value: false,
+			Usage: "Stop the onbranch command after the push step",
 		},
 		&cli.BoolFlag{
-			Name:  "clean",
+			Name:  cleanFlag,
 			Value: false,
+			Usage: "Delete the knative service",
 		},
 		&cli.StringFlag{
-			Name: "branchName",
+			Name:  branchNameFlag,
+			Usage: "Pass a branch name and disable autodetection",
 		},
 	}...)
 	return &cli.Command{
 		Name:  "onbranch",
-		Usage: "deploy the application as a knative service",
+		Usage: "Build, push and deploy the application using the branch name as version and namespace",
 		Flags: flags,
 		Action: func(cCtx *cli.Context) error {
-			if cCtx.Bool("clean") {
+			if cCtx.Bool(cleanFlag) {
 				return c.Delete(cCtx)
 			}
 
 			return c.buildPushDeploy(cCtx)
 		},
 		Before: func(ctx *cli.Context) error {
+			var err error
 			if err := c.loadFlagsFromConfig(ctx); err != nil {
 				return err
 			}
 
-			wd, err := os.Getwd()
+			branchName := ctx.String(branchNameFlag)
 
-			if err != nil {
-				return err
+			if branchName == "" {
+				branchName, err = git.GetBranchName()
+				if err != nil {
+					return err
+				}
 			}
-
-			repo, err := git.PlainOpen(wd)
-			if err != nil {
-				return err
-			}
-
-			head, err := repo.Head()
-			if err != nil {
-				return err
-			}
-
-			branchName := head.Name().Short()
 
 			ctx.Set(appVersionFlag, utils.EncodeRFC1123(branchName))
 			ctx.Set(namespaceFlag, utils.EncodeRFC1123(branchName))
@@ -96,6 +96,9 @@ func (c icli) OnBranchCMD() *cli.Command {
 			}
 			if ctx.Bool(stopOnPushFlag) {
 				ignoredFlags = append(ignoredFlags, []string{endpointFlag, tokenFlag, caCRTFlag, namespaceFlag}...)
+			}
+			if ctx.Bool(cleanFlag) {
+				ignoredFlags = append(ignoredFlags, []string{registryPasswordFlag, registryUserFlag}...)
 			}
 
 			return c.checkRequiredFlags(ctx, ignoredFlags)

--- a/src/services/git/repo.go
+++ b/src/services/git/repo.go
@@ -43,6 +43,22 @@ func GetHash() (string, error) {
 	return headRef.Hash().String(), nil
 }
 
+func GetBranchName() (string, error) {
+	repo, err := initRepo()
+
+	if err != nil {
+		return "", err
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+
+	branchName := head.Name().Short()
+	return branchName, nil
+}
+
 func getGithubRemote() (string, error) {
 	repo, err := initRepo()
 

--- a/src/services/k8s/knative.go
+++ b/src/services/k8s/knative.go
@@ -8,10 +8,9 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/nearform/initium-cli/src/services/docker"
 	"github.com/nearform/initium-cli/src/services/project"
-
-	"github.com/nearform/initium-cli/src/utils/logger"
 
 	corev1 "k8s.io/api/core/v1"
 	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -73,7 +72,7 @@ func loadManifest(project *project.Project, dockerImage docker.DockerImage) (*se
 }
 
 func Apply(namespace string, config *rest.Config, project *project.Project, dockerImage docker.DockerImage) error {
-	logger.PrintInfo("Deploying Knative service to " + config.Host)
+	log.Info("Deploying Knative service", "host", config.Host, "name", project.Name, "namespace", namespace)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 
@@ -140,7 +139,7 @@ func Apply(namespace string, config *rest.Config, project *project.Project, dock
 }
 
 func Clean(namespace string, config *rest.Config, project *project.Project) error {
-	logger.PrintInfo("Deleting Knative service from " + config.Host)
+	log.Info("Deleting Knative service", "host", config.Host, "name", project.Name, "namespace", namespace)
 	ctx := context.Background()
 
 	// Create a new Knative Serving client
@@ -154,6 +153,6 @@ func Clean(namespace string, config *rest.Config, project *project.Project) erro
 		return fmt.Errorf("deleting the service: %v", err)
 	}
 
-	logger.PrintInfo("Deleted Knative service " + project.Name)
+	log.Info("The Knative service was successfully deleted", "host", config.Host, "name", project.Name, "namespace", namespace)
 	return nil
 }


### PR DESCRIPTION
before this change the onbranch command would detect the branch from the git repository, this sometimes can cause problems given that the branch might not be there when merging a PR or closing a PR.