### PR TITLE
fix: avoid running closed PR action immediately after reopen

### DIFF
--- a/assets/github/onbranch.tmpl
+++ b/assets/github/onbranch.tmpl
@@ -28,6 +28,7 @@ jobs:
 
   closed_pr:
     if: github.event.action == 'closed'
+    concurrency: {{ `${{ github.head_ref }}` }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/assets/github/onmain.tmpl
+++ b/assets/github/onmain.tmpl
@@ -10,7 +10,7 @@ jobs:
   cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: build and deploy on {{ .DefaultBranch }}
         uses: docker://ghcr.io/nearform/initium-cli:latest


### PR DESCRIPTION
- Avoiding a deployment service to remain active after reopen & closing PR sequentially in a few secs time
- Update main pipeline checkout version to fix node12 warning in github actions