### PR TITLE
closes: Work with a developer to refine the default docker file for node

### DIFF
--- a/assets/docker/Dockerfile.node.tmpl
+++ b/assets/docker/Dockerfile.node.tmpl
@@ -1,11 +1,17 @@
 FROM node:{{ or .RuntimeVersion .DefaultRuntimeVersion }} AS build-env
-COPY . /src
-WORKDIR /src
+
+WORKDIR /app
+
+COPY package*.json tsconfig*.json ./
+
 RUN {{ .NodeInstallCommand }}
+
+COPY . /app
+
 RUN npm run build --if-present
 RUN npm test
 
 FROM gcr.io/distroless/nodejs20-debian11
-COPY --from=build-env /src /src
+COPY --from=build-env /app /src
 WORKDIR /src
-CMD ["index.js"]
+ENTRYPOINT ["index.js"]

--- a/assets/docker/Dockerfile.node.tmpl
+++ b/assets/docker/Dockerfile.node.tmpl
@@ -12,6 +12,6 @@ RUN npm run build --if-present
 RUN npm test
 
 FROM gcr.io/distroless/nodejs20-debian11
-COPY --from=build-env /app /src
-WORKDIR /src
+COPY --from=build-env /app /app
+WORKDIR /app
 ENTRYPOINT ["index.js"]

--- a/assets/docker/Dockerfile.node.tmpl
+++ b/assets/docker/Dockerfile.node.tmpl
@@ -14,4 +14,5 @@ RUN npm test
 FROM gcr.io/distroless/nodejs20-debian11
 COPY --from=build-env /app /app
 WORKDIR /app
+USER nonroot
 CMD ["index.js"]

--- a/assets/docker/Dockerfile.node.tmpl
+++ b/assets/docker/Dockerfile.node.tmpl
@@ -14,4 +14,4 @@ RUN npm test
 FROM gcr.io/distroless/nodejs20-debian11
 COPY --from=build-env /app /app
 WORKDIR /app
-ENTRYPOINT ["index.js"]
+CMD ["index.js"]


### PR DESCRIPTION
Node dockerfile: 
- Use caching layers in case the same runner or local builds it
- Rename workspace to avoid multiple src under the same path