### PR TITLE
feat: change released binary name to initium

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,8 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - env:
+  - binary: initium
+    env:
       - CGO_ENABLED=0
     goos:
       - linux


### PR DESCRIPTION
By default gorelease uses the repository name as binary name this is not great since we will end up with a binary called initium-cli.