### PR TITLE
fix: add annotations to ensure new docker image is downloaded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
 	github.com/urfave/cli/v2 v2.25.0
 	gopkg.in/yaml.v2 v2.4.0
+	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.27.1
 	k8s.io/apimachinery v0.27.1
 	k8s.io/client-go v0.27.1

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,7 @@ github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/skeema/knownhosts v1.1.1 h1:MTk78x9FPgDFVFkDLTrsnnfCJl7g1C/nnKvePgrIngE=
 github.com/skeema/knownhosts v1.1.1/go.mod h1:g4fPeYpque7P0xefxtGzV81ihjC8sX2IqpAoNkjxbMo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -402,6 +403,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -470,6 +472,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.27.1 h1:Z6zUGQ1Vd10tJ+gHcNNNgkV5emCyW+v2XTmn+CLjSd0=

--- a/src/cli/deploy.go
+++ b/src/cli/deploy.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/nearform/initium-cli/src/services/git"
 	knative "github.com/nearform/initium-cli/src/services/k8s"
 	"github.com/urfave/cli/v2"
 )
@@ -20,7 +21,12 @@ func (c *icli) Deploy(cCtx *cli.Context) error {
 		return err
 	}
 
-	return knative.Apply(cCtx.String(namespaceFlag), config, project, c.dockerImage)
+	commitSha, err := git.GetHash()
+	if err != nil {
+		return err
+	}
+
+	return knative.Apply(cCtx.String(namespaceFlag), commitSha, config, project, c.dockerImage)
 }
 
 func (c icli) DeployCMD() *cli.Command {

--- a/src/services/k8s/knative_test.go
+++ b/src/services/k8s/knative_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/base64"
 	"fmt"
+	"gotest.tools/v3/assert"
 	"os"
 	"path"
 	"testing"
@@ -54,22 +55,28 @@ func TestConfig(t *testing.T) {
 }
 
 func TestLoadManifest(t *testing.T) {
-	proj_knative := &project.Project{Name: "knative_test",
+	namespace := "custom"
+	commitSha := "93f4be93"
+
+	proj := &project.Project{Name: "knative_test",
 		Directory: path.Join(root, "example"),
 		Resources: os.DirFS(root),
 	}
 
-	docker_image := docker.DockerImage{
+	dockerImage := docker.DockerImage{
 		Registry:  "example.com",
 		Directory: ".",
 		Name:      "test",
 		Tag:       "v1.1.0",
 	}
 
-	_, err := loadManifest(proj_knative, docker_image)
+	serviceManifest, err := loadManifest(namespace, commitSha, proj, dockerImage)
 
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error: %v", err))
 	}
 
+	annotations := serviceManifest.Spec.Template.ObjectMeta.Annotations
+	assert.Assert(t, annotations[UpdateTimestampAnnotationName] != "", "Missing %s annotation", UpdateTimestampAnnotationName)
+	assert.Assert(t, annotations[UpdateShaAnnotationName] == commitSha, "Expected %s SHA, got %s", commitSha, annotations[UpdateShaAnnotationName])
 }


### PR DESCRIPTION
To ensure new Docker image being downloaded after a push to a branch we need to make changes to the knative service manifest. The following annotations are added on each deployment (`initium.nearform.com/updateSha` and `initium.nearform.com/updateTimestamp` for `spec.template.metadata.annotations`) to make sure repository changes are reflected in the cluster.

```yaml
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  annotations:
    serving.knative.dev/creator: system:serviceaccount:default:initium-cli-sa
    serving.knative.dev/lastModifier: system:serviceaccount:default:initium-cli-sa
  creationTimestamp: "2023-10-02T10:51:29Z"
  generation: 3
  name: initium-nodejs-demo-app
  namespace: initium-chore-another-pr
  resourceVersion: "8393"
  uid: cf8ef898-4092-4f3f-b0cf-2dca6b979e65
spec:
  template:
    metadata:
      annotations:
        initium.nearform.com/updateSha: 3eb1ba79fea98373648953266a9c502f1c88849c
        initium.nearform.com/updateTimestamp: "2023-10-02T12:56:34+02:00"
      creationTimestamp: null
    spec:
      containerConcurrency: 0
      containers:
      - image: ghcr.io/zaremba-tomasz/initium-nodejs-demo-app:initium-chore-another-pr
        imagePullPolicy: Always
        name: user-container
        readinessProbe:
          successThreshold: 1
          tcpSocket:
            port: 0
        resources: {}
      timeoutSeconds: 300
  traffic:
  - latestRevision: true
    percent: 100
```

Closes #103 