### PR TITLE
feat: config file schema versioning

### DIFF
--- a/assets/versions/versions.json
+++ b/assets/versions/versions.json
@@ -1,0 +1,4 @@
+{
+  "cliVersion": "v0.5.0",
+  "configFileSchemaVersion": "v1"
+}

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/nearform/initium-cli/src/services/docker"
+	"github.com/nearform/initium-cli/src/services/versions"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/nearform/initium-cli/src/utils/logger"
 	"github.com/urfave/cli/v2"
@@ -58,6 +59,14 @@ func (c icli) baseBeforeFunc(ctx *cli.Context) error {
 	if err := c.checkRequiredFlags(ctx, []string{}); err != nil {
 		return err
 	}
+
+	if ctx.Command.Name != "init" && ctx.Command.Name != "help" {
+		clientConfigFileName := ctx.String(configFileFlag)
+		if err := versions.CheckClientConfigFileSchemaMatchesCli(clientConfigFileName, c.Resources); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nearform/initium-cli/src/services/k8s"
 	"github.com/nearform/initium-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/services/versions"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 )
@@ -82,6 +83,16 @@ func (c icli) InitConfigCMD(ctx *cli.Context) error {
 
 		config = config + next
 	}
+
+	versionFileContent, err := versions.LoadCliVersionsFileContent(c.Resources)
+	if err != nil {
+		return err
+	}
+	configFileSchemaVersion, err := versions.GetCurrentCliConfigFileSchemaVersion(versionFileContent)
+	if err != nil {
+		return err
+	}
+	config = fmt.Sprintf("%s: %s\n", versions.ConfigFileSchemaVersionFlagName, configFileSchemaVersion) + config
 
 	if ctx.Bool(persistFlag) {
 		f, err := os.OpenFile(filepath.Join(ctx.String(projectDirectoryFlag), defaults.ConfigFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func compareConfig(t *testing.T, appName string, registry string, writer io.Writer) {
-	configTemplate := fmt.Sprintf(`app-name: %s
+	currentConfigVersion := "v1"
+	configTemplate := fmt.Sprintf(`schema-version: %s
+app-name: %s
 cluster-endpoint: null
 container-registry: %s
 default-branch: main
@@ -22,6 +24,7 @@ dockerfile-name: null
 registry-user: null
 runtime-version: null
 `,
+		currentConfigVersion,
 		appName,
 		registry,
 	)

--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/nearform/initium-cli/src/services/versions"
 
 	"github.com/nearform/initium-cli/src/services/git"
 	"github.com/nearform/initium-cli/src/utils"
@@ -75,6 +76,11 @@ func (c icli) OnBranchCMD() *cli.Command {
 		Before: func(ctx *cli.Context) error {
 			var err error
 			if err := c.loadFlagsFromConfig(ctx); err != nil {
+				return err
+			}
+
+			clientConfigFileName := ctx.String(configFileFlag)
+			if err := versions.CheckClientConfigFileSchemaMatchesCli(clientConfigFileName, c.Resources); err != nil {
 				return err
 			}
 

--- a/src/cli/onmain.go
+++ b/src/cli/onmain.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/nearform/initium-cli/src/services/versions"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 )
@@ -30,6 +31,11 @@ func (c *icli) OnMainCMD() *cli.Command {
 		Action: c.buildPushDeploy,
 		Before: func(ctx *cli.Context) error {
 			if err := c.loadFlagsFromConfig(ctx); err != nil {
+				return err
+			}
+
+			clientConfigFileName := ctx.String(configFileFlag)
+			if err := versions.CheckClientConfigFileSchemaMatchesCli(clientConfigFileName, c.Resources); err != nil {
 				return err
 			}
 

--- a/src/services/versions/versions.go
+++ b/src/services/versions/versions.go
@@ -1,0 +1,87 @@
+package versions
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/nearform/initium-cli/src/utils/defaults"
+	"gopkg.in/yaml.v2"
+	"io/fs"
+	"os"
+	"path"
+)
+
+const (
+	ConfigFileSchemaVersionFlagName = "schema-version"
+	InitialConfigFileSchemaVersion  = "v1"
+)
+
+type VersionsFile struct {
+	CliVersion              string `json:"cliVersion"`
+	ConfigFileSchemaVersion string `json:"configFileSchemaVersion"`
+}
+
+func LoadCliVersionsFileContent(resources fs.FS) ([]byte, error) {
+	bytes, err := fs.ReadFile(resources, path.Join("assets", "versions", "versions.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+func GetCurrentCliConfigFileSchemaVersion(cliVersionsFileContent []byte) (string, error) {
+	var versionsFile VersionsFile
+	err := json.Unmarshal(cliVersionsFileContent, &versionsFile)
+	if err != nil {
+		return "", err
+	}
+
+	return versionsFile.ConfigFileSchemaVersion, nil
+}
+
+func CheckClientConfigFileSchemaMatchesCli(clientConfigFile string, resources fs.FS) error {
+	//TODO: copied from flags.go, it would be nice to extract config file loading
+	//if the default config file doesn't exist we can ignore the rest and return nil
+	_, err := os.Stat(clientConfigFile)
+	if err != nil && errors.Is(err, os.ErrNotExist) && clientConfigFile == defaults.ConfigFile {
+		return nil
+	}
+
+	clientConfigFileContent, err := os.ReadFile(clientConfigFile)
+	if err != nil {
+		return err
+	}
+
+	cliVersionsFileContent, err := LoadCliVersionsFileContent(resources)
+	if err != nil {
+		return err
+	}
+
+	return ensureConfigFileSchemaVersionMatchesCli(clientConfigFileContent, cliVersionsFileContent)
+}
+
+func ensureConfigFileSchemaVersionMatchesCli(clientConfigFileContent []byte, cliVersionsFileContent []byte) error {
+	currentCliConfigFileVersion, err := GetCurrentCliConfigFileSchemaVersion(cliVersionsFileContent)
+	if err != nil {
+		return err
+	}
+
+	clientConfigFile := make(map[string]string)
+	err = yaml.Unmarshal(clientConfigFileContent, &clientConfigFile)
+	if err != nil {
+		return err
+	}
+
+	clientConfigFileVersion := ""
+	if clientConfigFile[ConfigFileSchemaVersionFlagName] == "" && currentCliConfigFileVersion == InitialConfigFileSchemaVersion {
+		clientConfigFileVersion = InitialConfigFileSchemaVersion
+	} else {
+		clientConfigFileVersion = clientConfigFile[ConfigFileSchemaVersionFlagName]
+	}
+
+	if currentCliConfigFileVersion != clientConfigFileVersion {
+		return errors.New("client config file schema version does not match the one expected by the CLI")
+	}
+
+	return nil
+}

--- a/src/services/versions/versions_test.go
+++ b/src/services/versions/versions_test.go
@@ -1,0 +1,98 @@
+package versions
+
+import (
+	"encoding/json"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+type ClientConfigFile struct {
+	SchemaVersion string `yaml:"schema-version"`
+	AppName       string `yaml:"app-name"`
+}
+
+func TestShouldReturnCurrentCliConfigFileSchemaVersion(t *testing.T) {
+	cliConfigFileSchemaVersion := InitialConfigFileSchemaVersion
+	bytes, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	schemaVersion, err := GetCurrentCliConfigFileSchemaVersion(bytes)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	assert.Assert(t, schemaVersion == cliConfigFileSchemaVersion, fmt.Sprintf("Expected: %s, got: %s", cliConfigFileSchemaVersion, schemaVersion))
+}
+
+func TestShouldBeBackwardCompatibleWhenClientConfigIsMissingSchemaVersion(t *testing.T) {
+	cliConfigFileSchemaVersion := InitialConfigFileSchemaVersion
+	cliVersionsFileContent, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	clientConfigFileContent, err := getClientConfigFileContent("")
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	err = ensureConfigFileSchemaVersionMatchesCli(clientConfigFileContent, cliVersionsFileContent)
+	assert.NilError(t, err, "Expected error not present, got: %v", err)
+}
+
+func TestShouldAcceptTheClientConfigFileWhenSchemaVersionMatches(t *testing.T) {
+	cliConfigFileSchemaVersion := InitialConfigFileSchemaVersion
+	cliVersionsFileContent, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	clientConfigFileContent, err := getClientConfigFileContent(InitialConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	err = ensureConfigFileSchemaVersionMatchesCli(clientConfigFileContent, cliVersionsFileContent)
+	assert.NilError(t, err, "Expected error not present, got: %v", err)
+}
+
+func TestShouldReturnAnErrorWhenThereIsAMismatchBetweenSchemaVersions(t *testing.T) {
+	cliConfigFileSchemaVersion := "v2"
+	cliVersionsFileContent, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	clientConfigFileContent, err := getClientConfigFileContent(InitialConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	err = ensureConfigFileSchemaVersionMatchesCli(clientConfigFileContent, cliVersionsFileContent)
+	assert.Error(t, err, "client config file schema version does not match the one expected by the CLI")
+}
+
+func getCliVersionsFileContent(schemaVersion string) ([]byte, error) {
+	versionsFile := VersionsFile{
+		CliVersion:              "v0.5.0",
+		ConfigFileSchemaVersion: schemaVersion,
+	}
+	return json.Marshal(versionsFile)
+}
+
+func getClientConfigFileContent(schemaVersion string) ([]byte, error) {
+	if schemaVersion == "" {
+		return yaml.Marshal(ClientConfigFile{
+			AppName: "initium-nodejs-demo-app",
+		})
+	} else {
+		return yaml.Marshal(ClientConfigFile{
+			SchemaVersion: schemaVersion,
+			AppName:       "initium-nodejs-demo-app",
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a config file schema versioning mechanism. The schema version is kept in the `versions.json` file and will be manually updated and needed. Each command of the CLI which works with `.initium.yaml` file should compare the version within the file with the one embedded in the binary and decide whether it can proceed or not.

Closes https://github.com/nearform/initium-cli/issues/116.