### PR TITLE
feat: version command introduced

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,10 @@
           "type": "json",
           "path": "npm/package-lock.json",
           "jsonpath": "$.packages[''].version"
+        }, {
+          "type": "json",
+          "path": "assets/versions/versions.json",
+          "jsonpath": "$.cliVersion"
         }
       ]
     }

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -52,18 +52,20 @@ func New(resources fs.FS) icli {
 }
 
 func (c icli) baseBeforeFunc(ctx *cli.Context) error {
-	if err := c.loadFlagsFromConfig(ctx); err != nil {
-		return err
-	}
-
-	if err := c.checkRequiredFlags(ctx, []string{}); err != nil {
-		return err
-	}
-
-	if ctx.Command.Name != "init" && ctx.Command.Name != "help" {
-		clientConfigFileName := ctx.String(configFileFlag)
-		if err := versions.CheckClientConfigFileSchemaMatchesCli(clientConfigFileName, c.Resources); err != nil {
+	if ctx.Command.Name != "version" {
+		if err := c.loadFlagsFromConfig(ctx); err != nil {
 			return err
+		}
+
+		if err := c.checkRequiredFlags(ctx, []string{}); err != nil {
+			return err
+		}
+
+		if ctx.Command.Name != "init" && ctx.Command.Name != "help" {
+			clientConfigFileName := ctx.String(configFileFlag)
+			if err := versions.CheckClientConfigFileSchemaMatchesCli(clientConfigFileName, c.Resources); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -146,6 +148,7 @@ func (c icli) Run(args []string) error {
 			c.OnBranchCMD(),
 			c.TemplateCMD(),
 			c.InitCMD(),
+			c.VersionCMD(),
 		},
 		Before: func(ctx *cli.Context) error {
 			if err := c.loadFlagsFromConfig(ctx); err != nil {

--- a/src/cli/version.go
+++ b/src/cli/version.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"github.com/nearform/initium-cli/src/services/versions"
+	"github.com/nearform/initium-cli/src/utils/logger"
+	"github.com/urfave/cli/v2"
+)
+
+func (c *icli) Version(cCtx *cli.Context) error {
+	cliVersionsFileContent, err := versions.LoadCliVersionsFileContent(c.Resources)
+	if err != nil {
+		return err
+	}
+
+	cliVersion, err := versions.GetCliVersion(cliVersionsFileContent)
+	if err != nil {
+		return err
+	}
+
+	logger.PrintInfo("initium CLI version: " + cliVersion)
+
+	return nil
+}
+
+func (c icli) VersionCMD() *cli.Command {
+	return &cli.Command{
+		Name:   "version",
+		Usage:  "show the initium CLI version",
+		Flags:  nil,
+		Action: c.Version,
+		Before: c.baseBeforeFunc,
+	}
+}

--- a/src/services/versions/versions.go
+++ b/src/services/versions/versions.go
@@ -29,6 +29,16 @@ func LoadCliVersionsFileContent(resources fs.FS) ([]byte, error) {
 	return bytes, nil
 }
 
+func GetCliVersion(cliVersionsFileContent []byte) (string, error) {
+	var versionsFile VersionsFile
+	err := json.Unmarshal(cliVersionsFileContent, &versionsFile)
+	if err != nil {
+		return "", err
+	}
+
+	return versionsFile.CliVersion, nil
+}
+
 func GetCurrentCliConfigFileSchemaVersion(cliVersionsFileContent []byte) (string, error) {
 	var versionsFile VersionsFile
 	err := json.Unmarshal(cliVersionsFileContent, &versionsFile)

--- a/src/services/versions/versions_test.go
+++ b/src/services/versions/versions_test.go
@@ -13,6 +13,8 @@ type ClientConfigFile struct {
 	AppName       string `yaml:"app-name"`
 }
 
+const cliVersion = "v0.5.0"
+
 func TestShouldReturnCurrentCliConfigFileSchemaVersion(t *testing.T) {
 	cliConfigFileSchemaVersion := InitialConfigFileSchemaVersion
 	bytes, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
@@ -26,6 +28,21 @@ func TestShouldReturnCurrentCliConfigFileSchemaVersion(t *testing.T) {
 	}
 
 	assert.Assert(t, schemaVersion == cliConfigFileSchemaVersion, fmt.Sprintf("Expected: %s, got: %s", cliConfigFileSchemaVersion, schemaVersion))
+}
+
+func TestShouldReturnCliVersion(t *testing.T) {
+	cliConfigFileSchemaVersion := InitialConfigFileSchemaVersion
+	cliVersionsFileContent, err := getCliVersionsFileContent(cliConfigFileSchemaVersion)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	version, err := GetCliVersion(cliVersionsFileContent)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error: %s", err))
+	}
+
+	assert.Assert(t, version == cliVersion, fmt.Sprintf("Expected: %s, got: %s", cliVersion, version))
 }
 
 func TestShouldBeBackwardCompatibleWhenClientConfigIsMissingSchemaVersion(t *testing.T) {
@@ -78,7 +95,7 @@ func TestShouldReturnAnErrorWhenThereIsAMismatchBetweenSchemaVersions(t *testing
 
 func getCliVersionsFileContent(schemaVersion string) ([]byte, error) {
 	versionsFile := VersionsFile{
-		CliVersion:              "v0.5.0",
+		CliVersion:              cliVersion,
 		ConfigFileSchemaVersion: schemaVersion,
 	}
 	return json.Marshal(versionsFile)


### PR DESCRIPTION
The following introduces `version` command which returns the current version of the initium CLI.

Closes https://github.com/nearform/initium-cli/issues/120.