### PR TITLE
feat: provide an option to deploy private services

### DIFF
--- a/assets/knative/service.yaml.tmpl
+++ b/assets/knative/service.yaml.tmpl
@@ -3,10 +3,6 @@ kind: Service
 metadata:
   name: {{ .Name }}
   namespace: default
-  labels:
-  {{ if .PrivateService }}
-      networking.knative.dev/visibility: cluster-local
-  {{ end }}
 spec:
   template:
     spec:

--- a/assets/knative/service.yaml.tmpl
+++ b/assets/knative/service.yaml.tmpl
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ .Name }}
   namespace: default
+  labels:
+  {{ if .PrivateService }}
+      networking.knative.dev/visibility: cluster-local
+  {{ end }}
 spec:
   template:
     spec:

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -79,7 +79,6 @@ func (c *icli) init(cCtx *cli.Context) error {
 	registry := cCtx.String(repoNameFlag)
 	imagePullSecrets := cCtx.StringSlice(imagePullSecretsFlag)
 	dockerFileName := cCtx.String(dockerFileNameFlag)
-	isPublicService := cCtx.Bool(isPublicServiceFlag)
 
 	if dockerFileName == "" {
 		dockerFileName = defaults.GeneratedDockerFile
@@ -95,7 +94,7 @@ func (c *icli) init(cCtx *cli.Context) error {
 		projectDirectory,
 		cCtx.String(runtimeVersionFlag),
 		version,
-		isPublicService,
+		cCtx.Bool(isPrivateServiceFlag),
 		imagePullSecrets,
 		c.Resources,
 	)

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -79,6 +79,7 @@ func (c *icli) init(cCtx *cli.Context) error {
 	registry := cCtx.String(repoNameFlag)
 	imagePullSecrets := cCtx.StringSlice(imagePullSecretsFlag)
 	dockerFileName := cCtx.String(dockerFileNameFlag)
+	isPublicService := cCtx.Bool(isPublicServiceFlag)
 
 	if dockerFileName == "" {
 		dockerFileName = defaults.GeneratedDockerFile
@@ -94,6 +95,7 @@ func (c *icli) init(cCtx *cli.Context) error {
 		projectDirectory,
 		cCtx.String(runtimeVersionFlag),
 		version,
+		isPublicService,
 		imagePullSecrets,
 		c.Resources,
 	)

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -46,6 +46,7 @@ const (
 	stopOnBuildFlag       string = "stop-on-build"
 	stopOnPushFlag        string = "stop-on-push"
 	envVarFileFlag        string = "env-var-file"
+	isPublicServiceFlag   string = "public"
 )
 
 type flags struct {
@@ -155,6 +156,12 @@ func InitFlags() flags {
 					Usage:   "read parameters from config",
 					Value:   defaults.ConfigFile,
 					EnvVars: []string{"INITIUM_CONFIG_FILE"},
+				},
+				&cli.BoolFlag{
+					Name:     isPublicServiceFlag,
+					Usage:    "will deploy the service as accessible from outside of the cluster",
+					Category: "init",
+					Value:    false,
 				},
 			},
 			Shared: []cli.Flag{

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -86,6 +87,13 @@ func (c icli) InitConfigCMD(ctx *cli.Context) error {
 			}
 			n = stringSliceFlag.Name
 			v = strings.Join(ctx.StringSlice(stringSliceFlag.Name), ",")
+		case *cli.BoolFlag:
+			boolFlag := flag.(*cli.BoolFlag)
+			if slices.Contains(excludedFlags, boolFlag.Name) {
+				continue
+			}
+			n = boolFlag.Name
+			v = strconv.FormatBool(ctx.Bool(boolFlag.Name))
 		}
 
 		if v == "" {

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -13,19 +13,19 @@ import (
 	"github.com/charmbracelet/log"
 )
 
-func compareConfig(t *testing.T, appName string, registry string, isPublicService bool, writer io.Writer) {
+func compareConfig(t *testing.T, appName string, registry string, isPrivateService bool, writer io.Writer) {
 	configTemplate := fmt.Sprintf(`app-name: %s
 container-registry: %s
 default-branch: main
 dockerfile-name: null
 env-var-file: .env.initium
 image-pull-secrets: null
-public: %t
+private: %t
 runtime-version: null
 `,
 		appName,
 		registry,
-		isPublicService,
+		isPrivateService,
 	)
 
 	result := fmt.Sprint(writer.(*bytes.Buffer))

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -20,7 +20,7 @@ default-branch: main
 dockerfile-name: null
 env-var-file: .env.initium
 image-pull-secrets: null
-public: %b
+public: %t
 runtime-version: null
 `,
 		appName,
@@ -135,19 +135,6 @@ func TestAppName(t *testing.T) {
 	cli := geticliForTesting(os.DirFS("../.."))
 
 	err := cli.Run([]string{"initium", "build"})
-	if err == nil {
-		t.Errorf("CLI should ask for %s and %s if not detected", appNameFlag, repoNameFlag)
-	}
-
-	if !(strings.Contains(err.Error(), appNameFlag) && strings.Contains(err.Error(), repoNameFlag)) {
-		t.Errorf("the error message should contain %s and %s", appNameFlag, repoNameFlag)
-	}
-}
-
-func TestPublicKnativeService(t *testing.T) {
-	cli := GeticliForTesting(os.DirFS("../.."))
-
-	err := cli.Run([]string{"initium", "init"})
 	if err == nil {
 		t.Errorf("CLI should ask for %s and %s if not detected", appNameFlag, repoNameFlag)
 	}

--- a/src/services/k8s/knative.go
+++ b/src/services/k8s/knative.go
@@ -54,9 +54,10 @@ func loadManifest(namespace string, commitSha string, project *project.Project, 
 	}
 
 	templateParams := map[string]interface{}{
-		"Name": dockerImage.Name,
-		"RemoteTag": dockerImage.RemoteTag(),
+		"Name":             dockerImage.Name,
+		"RemoteTag":        dockerImage.RemoteTag(),
 		"ImagePullSecrets": project.ImagePullSecrets,
+		"PrivateService":   !project.IsPublicService,
 	}
 
 	output := &bytes.Buffer{}

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -27,6 +27,7 @@ type Project struct {
 	DefaultRuntimeVersion string
 	ImagePullSecrets      []string
 	Resources             fs.FS
+	IsPublicService       bool
 }
 
 type InitOptions struct {
@@ -44,7 +45,7 @@ func GuessAppName() *string {
 	return &name
 }
 
-func New(name string, directory string, runtimeVersion string, version string, imagePullSecrets []string, resources fs.FS) Project {
+func New(name string, directory string, runtimeVersion string, version string, isPublicService bool, imagePullSecrets []string, resources fs.FS) Project {
 	return Project{
 		Name:             name,
 		Directory:        directory,
@@ -52,6 +53,7 @@ func New(name string, directory string, runtimeVersion string, version string, i
 		ImagePullSecrets: imagePullSecrets,
 		Resources:        resources,
 		Version:          version,
+		IsPublicService:  isPublicService,
 	}
 }
 

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -27,7 +27,7 @@ type Project struct {
 	DefaultRuntimeVersion string
 	ImagePullSecrets      []string
 	Resources             fs.FS
-	IsPublicService       bool
+	IsPrivate             bool
 }
 
 type InitOptions struct {
@@ -45,7 +45,7 @@ func GuessAppName() *string {
 	return &name
 }
 
-func New(name string, directory string, runtimeVersion string, version string, isPublicService bool, imagePullSecrets []string, resources fs.FS) Project {
+func New(name string, directory string, runtimeVersion string, version string, isPrivate bool, imagePullSecrets []string, resources fs.FS) Project {
 	return Project{
 		Name:             name,
 		Directory:        directory,
@@ -53,7 +53,7 @@ func New(name string, directory string, runtimeVersion string, version string, i
 		ImagePullSecrets: imagePullSecrets,
 		Resources:        resources,
 		Version:          version,
-		IsPublicService:  isPublicService,
+		IsPrivate:        isPrivate,
 	}
 }
 


### PR DESCRIPTION
TODO:

- [x]  flag value is not loaded properly from the persisted config file
- [x] flag location might be something worth discussing
- [x] compilation issue after rebase on latest `main`

# Testing

Should output the knative manifest without labels
```bash
go run main.go deploy --dry-run
```

Should output the knative manifest with a labels with value `cluster-local`
```bash
go run main.go deploy --dry-run --private
```

Similarly you could generate the config with and run deploy to get a similar output:

```bash
go run mian.go init config --private --persist
go run main.go deploy --dry-run
```

