### PR TITLE
fix: npm readme

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -64,8 +64,8 @@ jobs:
         shell: bash
         run: |
           cd npm
-          ./publish.sh
           ln ../README.md README.md
+          ./publish.sh
         env:
           NPM_TOKEN: ${{ secrets[format('NPM_TOKEN_{0}', steps.commit_author.outputs.author)] || secrets.NPM_TOKEN }}
           OPTIC_TOKEN: ${{ secrets[format('OPTIC_TOKEN_{0}', steps.commit_author.outputs.author)] || secrets.OPTIC_TOKEN }}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,1 +1,0 @@
-../README.md


### PR DESCRIPTION
This PR creates a symbolic link to README.md in the `npm` folder so the same readme is displayed in GitHub and NPM.

To test: clone this branch and see if the npm/README.md file is populated. We also will need to check the next release to see if the README will be populated in the NPM website.

Closes #137 