### PR TITLE
feat: k8s secrets management through initium abstraction

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -151,6 +151,7 @@ func (c icli) Run(args []string) error {
 			c.OnMainCMD(),
 			c.OnBranchCMD(),
 			c.TemplateCMD(),
+			c.SecretsCMD(),
 			c.InitCMD(),
 			{
 				Name:  "version",

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/nearform/initium-cli/src/services/git"
 	"github.com/nearform/initium-cli/src/services/project"
+	"github.com/nearform/initium-cli/src/utils"
 	"github.com/nearform/initium-cli/src/utils/defaults"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
@@ -316,4 +317,20 @@ func (c icli) CommandFlags(commands []FlagsType) []cli.Flag {
 	}
 
 	return result
+}
+
+func (icli) detectFlagsFromGit(ctx *cli.Context) (error) {
+	var err error
+	branchName := ctx.String(branchNameFlag)
+
+	if branchName == "" {
+		branchName, err = git.GetBranchName()
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx.Set(appVersionFlag, utils.EncodeRFC1123(branchName))
+	ctx.Set(namespaceFlag, utils.EncodeRFC1123(branchName))
+	return nil
 }

--- a/src/cli/onbranch.go
+++ b/src/cli/onbranch.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/nearform/initium-cli/src/services/git"
-	"github.com/nearform/initium-cli/src/utils"
 	"github.com/urfave/cli/v2"
 )
 
@@ -73,22 +71,14 @@ func (c icli) OnBranchCMD() *cli.Command {
 			return c.buildPushDeploy(cCtx)
 		},
 		Before: func(ctx *cli.Context) error {
-			var err error
 			if err := c.loadFlagsFromConfig(ctx); err != nil {
 				return err
 			}
 
-			branchName := ctx.String(branchNameFlag)
-
-			if branchName == "" {
-				branchName, err = git.GetBranchName()
-				if err != nil {
-					return err
-				}
+			err := c.detectFlagsFromGit(ctx)
+			if err != nil {
+				return err
 			}
-
-			ctx.Set(appVersionFlag, utils.EncodeRFC1123(branchName))
-			ctx.Set(namespaceFlag, utils.EncodeRFC1123(branchName))
 
 			ignoredFlags := []string{}
 			if ctx.Bool(stopOnBuildFlag) {

--- a/src/cli/secrets.go
+++ b/src/cli/secrets.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"github.com/nearform/initium-cli/src/services/k8s"
+	"github.com/urfave/cli/v2"
+)
+
+func (c *icli) ListSecretsCMD(cCtx *cli.Context) error {
+
+	config, err := k8s.Config(
+		cCtx.String(endpointFlag),
+		cCtx.String(tokenFlag),
+		[]byte(cCtx.String(caCRTFlag)),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = k8s.ListSecrets(
+		config, cCtx.String(namespaceFlag))
+	if err != nil {
+		return err
+	}
+
+	return nil
+	// Convert to string separating each item on the proper line
+	// Convert secrets to a string that will show a result similar to `kubectl get secrets`
+
+}
+
+func (c icli) SecretsCMD() *cli.Command {
+	flags := c.CommandFlags([]FlagsType{
+		Kubernetes,
+		Shared,
+	})
+
+	flags = append(flags, []cli.Flag{
+		&cli.StringFlag{
+			Name:  branchNameFlag,
+			Usage: "Pass a branch name and disable autodetection",
+		},
+	}...)
+
+	return &cli.Command{
+		Name:  "secrets",
+		Usage: "manage k8s secrets for apps deployed through Initium", // TODO: Consider a 'initium' prefix for secrets created through this command
+		Flags: flags,
+		Before: func(ctx *cli.Context) error {
+			var err error
+			err = c.detectFlagsFromGit(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = c.baseBeforeFunc(ctx)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Subcommands: []*cli.Command{
+			{
+				Name:   "list",
+				Usage:  "list secrets managed by initium",
+				Action: c.ListSecretsCMD,
+				Before: c.baseBeforeFunc,
+			},
+		},
+	}
+}

--- a/src/cli/secrets.go
+++ b/src/cli/secrets.go
@@ -2,30 +2,43 @@ package cli
 
 import (
 	"github.com/nearform/initium-cli/src/services/k8s"
+	"github.com/nearform/initium-cli/src/utils/logger"
 	"github.com/urfave/cli/v2"
+	"k8s.io/client-go/rest"
 )
 
 func (c *icli) ListSecretsCMD(cCtx *cli.Context) error {
-
-	config, err := k8s.Config(
-		cCtx.String(endpointFlag),
-		cCtx.String(tokenFlag),
-		[]byte(cCtx.String(caCRTFlag)),
-	)
+	config, err := setK8sConfig(cCtx)
 	if err != nil {
 		return err
 	}
 
-	_, err = k8s.ListSecrets(
+	stringSecretList, err := k8s.ListSecrets(
 		config, cCtx.String(namespaceFlag))
 	if err != nil {
 		return err
 	}
 
+	logger.PrintInfo(stringSecretList)
 	return nil
-	// Convert to string separating each item on the proper line
-	// Convert secrets to a string that will show a result similar to `kubectl get secrets`
+}
 
+func (c *icli) CreateSecretsCMD(cCtx *cli.Context) error {
+	config, err := setK8sConfig(cCtx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Secret name must be provided as argument
+	// TODO: Validate at least 1 key/value
+	// TODO: Validate same number of keys/values
+	// TODO: Use all flag values
+	err = k8s.CreateSecret(config, cCtx.String("name"), cCtx.StringSlice("key")[0], cCtx.StringSlice("value")[0], cCtx.String(namespaceFlag))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c icli) SecretsCMD() *cli.Command {
@@ -65,6 +78,35 @@ func (c icli) SecretsCMD() *cli.Command {
 				Action: c.ListSecretsCMD,
 				Before: c.baseBeforeFunc,
 			},
+			{
+				Name:   "create",
+				Usage:  "create a secret",
+				Action: c.CreateSecretsCMD,
+				Before: c.baseBeforeFunc,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "name",
+						Usage: "Secret name",
+					},					
+					&cli.StringSliceFlag{
+						Name:  "key",
+						Usage: "Secret key. Must be used in conjunction with --value. Allows multiple, and order matters",
+					},
+					&cli.StringSliceFlag{
+						Name:  "value",
+						Usage: "Secret value. Allows multiple, and they must be in the same order as the respective --key",
+					},
+				},
+			},
 		},
 	}
+}
+
+func setK8sConfig(cCtx *cli.Context) (*rest.Config, error) {
+	config, err := k8s.Config(
+		cCtx.String(endpointFlag),
+		cCtx.String(tokenFlag),
+		[]byte(cCtx.String(caCRTFlag)),
+	)
+	return config, err
 }

--- a/src/cli/secrets.go
+++ b/src/cli/secrets.go
@@ -41,6 +41,20 @@ func (c *icli) CreateSecretsCMD(cCtx *cli.Context) error {
 	return nil
 }
 
+func (c *icli) UpdateSecretsCMD(cCtx *cli.Context) error {
+	config, err := setK8sConfig(cCtx)
+	if err != nil {
+		return err
+	}
+
+	err = k8s.UpdateSecret(config, cCtx.String("name"), cCtx.String("key"), cCtx.String("value"), cCtx.String(namespaceFlag))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c icli) SecretsCMD() *cli.Command {
 	flags := c.CommandFlags([]FlagsType{
 		Kubernetes,
@@ -73,12 +87,6 @@ func (c icli) SecretsCMD() *cli.Command {
 		},
 		Subcommands: []*cli.Command{
 			{
-				Name:   "list",
-				Usage:  "list secrets managed by initium",
-				Action: c.ListSecretsCMD,
-				Before: c.baseBeforeFunc,
-			},
-			{
 				Name:   "create",
 				Usage:  "create a secret",
 				Action: c.CreateSecretsCMD,
@@ -87,14 +95,46 @@ func (c icli) SecretsCMD() *cli.Command {
 					&cli.StringFlag{
 						Name:  "name",
 						Usage: "Secret name",
+						Required: true,
 					},					
 					&cli.StringSliceFlag{
 						Name:  "key",
 						Usage: "Secret key. Must be used in conjunction with --value. Allows multiple, and order matters",
+						Required: true,
 					},
 					&cli.StringSliceFlag{
 						Name:  "value",
 						Usage: "Secret value. Allows multiple, and they must be in the same order as the respective --key",
+						Required: true,
+					},
+				},
+			},
+			{
+				Name:   "get",
+				Usage:  "get secrets managed by initium",
+				Action: c.ListSecretsCMD,
+				Before: c.baseBeforeFunc,
+			},
+			{
+				Name:   "update",
+				Usage:  "update secrets managed by initium",
+				Action: c.UpdateSecretsCMD,
+				Before: c.baseBeforeFunc,
+				Flags: []cli.Flag{		
+					&cli.StringFlag{
+						Name:  "name", // TODO: Move 'name', 'key' and 'values' as constants
+						Usage: "Secret name",
+						Required: true,
+					},			
+					&cli.StringFlag{
+						Name:  "key",
+						Usage: "Secret key. Must be used in conjunction with --value",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:  "value",
+						Usage: "Secret value",
+						Required: true,
 					},
 				},
 			},

--- a/src/services/k8s/secrets.go
+++ b/src/services/k8s/secrets.go
@@ -1,0 +1,70 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func ListSecrets(config *rest.Config, namespace string) (*v1.SecretList, error)  {
+	ctx := context.Background()
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Creating K8s client %v", err)
+	}
+
+	secretList, err := client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		return nil, fmt.Errorf("Error fetching K8s secret %v", err)
+	}
+	return secretList, nil
+}
+
+func GetSecret(config *rest.Config, secretName string, namespace string) (*v1.Secret, error) {
+	ctx := context.Background()
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Creating K8s client %v", err)
+	}
+
+	secret, err := getSecretUsingExistingCtx(client, ctx, secretName, namespace)
+	if err == nil {
+		return nil, fmt.Errorf("Error fetching K8s secret %v", err)
+	}
+	return secret, nil
+}
+
+func UpdateSecretKeyValue(config *rest.Config, secretName string, secretKey string, secretValue string, namespace string) error {
+	ctx := context.Background()
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Creating K8s client %v", err)
+	}
+
+	secret, err := getSecretUsingExistingCtx(client, ctx, secretName, namespace)
+	if err == nil {
+		return fmt.Errorf("Error fetching K8s secret %v", err)
+	}
+
+	secret.Data[secretKey] = []byte(secretValue)
+	_, err = client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("Updating K8s secret %v", err)
+	}
+	log.Infof("K8s secret: %v was successfully updated", secretName)
+
+	return nil
+}
+
+func getSecretUsingExistingCtx(client *kubernetes.Clientset, ctx context.Context, secretName string, namespace string) (*v1.Secret, error) {
+	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err == nil {
+		return nil, fmt.Errorf("Error fetching K8s secret %v", err)
+	}
+	return secret, nil
+}

--- a/src/services/k8s/secrets.go
+++ b/src/services/k8s/secrets.go
@@ -17,8 +17,11 @@ func ListSecrets(config *rest.Config, namespace string) (string, error) {
 		var sb strings.Builder
 		for _, secret := range secretList.Items {
 			sb.WriteString(
-				fmt.Sprintf("-name: %v\n namespace: %v\n", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace),
+				fmt.Sprintf("-name: %v\n namespace: %v\n data:\n", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace),
 			)
+			for key, value := range secret.Data {
+				sb.WriteString(fmt.Sprintf("  %s: %s", key, string(value)))
+			}
 		}
 		return sb.String()
 	}
@@ -36,20 +39,6 @@ func ListSecrets(config *rest.Config, namespace string) (string, error) {
 	}
 
 	return formatSecretListOutput(secretList), nil
-}
-
-func GetSecret(config *rest.Config, secretName string, namespace string) (*v1.Secret, error) {
-	ctx := context.Background()
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("Creating K8s client %v", err)
-	}
-
-	secret, err := getSecretUsingExistingCtx(client, ctx, secretName, namespace)
-	if err == nil {
-		return nil, fmt.Errorf("Error fetching K8s secret %v", err)
-	}
-	return secret, nil
 }
 
 func CreateSecret(config *rest.Config, secretName string, secretKey string, secretValue string, namespace string) error {

--- a/src/services/k8s/secrets.go
+++ b/src/services/k8s/secrets.go
@@ -78,7 +78,7 @@ func CreateSecret(config *rest.Config, secretName string, secretKey string, secr
 	return nil
 }
 
-func UpdateSecretKeyValue(config *rest.Config, secretName string, secretKey string, secretValue string, namespace string) error {
+func UpdateSecret(config *rest.Config, secretName string, secretKey string, secretValue string, namespace string) error {
 	ctx := context.Background()
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/src/services/k8s/secrets.go
+++ b/src/services/k8s/secrets.go
@@ -3,15 +3,31 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/log"
+	"github.com/nearform/initium-cli/src/utils/logger"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func ListSecrets(config *rest.Config, namespace string) (*v1.SecretList, error)  {
+func ListSecrets(config *rest.Config, namespace string) (*v1.SecretList, error) {
+	convertSecretListToString := func (secretList *v1.SecretList) string {
+	    var sb strings.Builder
+
+	    for _, secret := range secretList.Items {
+	        sb.WriteString(fmt.Sprintf("%s\n", secret.ObjectMeta.Name))
+	        for key := range secret.Data {
+	            sb.WriteString(fmt.Sprintf("  %s\n", key))
+	        }
+	        sb.WriteString("\n")
+	    }
+
+	    return sb.String()
+	}
+
 	ctx := context.Background()
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -19,9 +35,17 @@ func ListSecrets(config *rest.Config, namespace string) (*v1.SecretList, error) 
 	}
 
 	secretList, err := client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
-	if err == nil {
-		return nil, fmt.Errorf("Error fetching K8s secret %v", err)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error fetching K8s secret %v", err.Error())
 	}
+
+	stringSecretList := convertSecretListToString(secretList);
+	logger.PrintInfo("*********** CODEIUM CONVERTED"); // TODO: Return this and print it from CMD
+	logger.PrintInfo(stringSecretList); // TODO: Return this and print it from CMD
+	logger.PrintInfo("*********** SECRETLIST.STRING NATIVE METHOD"); // TODO: Return this and print it from CMD
+	logger.PrintInfo(secretList.String()); // TODO: Return this and print it from CMD
+
 	return secretList, nil
 }
 
@@ -56,7 +80,7 @@ func UpdateSecretKeyValue(config *rest.Config, secretName string, secretKey stri
 	if err != nil {
 		return fmt.Errorf("Updating K8s secret %v", err)
 	}
-	log.Infof("K8s secret: %v was successfully updated", secretName)
+	log.Infof("K8s secret: %v key: %v was successfully updated", secretName, secretKey)
 
 	return nil
 }
@@ -68,3 +92,5 @@ func getSecretUsingExistingCtx(client *kubernetes.Clientset, ctx context.Context
 	}
 	return secret, nil
 }
+
+// TODO: Test interactive edit mode. Use secrets.go from k8s service package.


### PR DESCRIPTION
THIS IS WORK IN PROGRESS

- List, Get, Create and Update secrets.
- Create allow multiple key/values
- Auto detect branch as namespace

Near future idea:
- Use GH Actions workflow to get a secret from GH and transform that into a k8s secret through Initium CLI. This would give a nicer user experience, as GH secrets is the only location where this person would have to handle sensitive information. It's also consistent with current deploy flow.