### PR TITLE
fix: cluster name for INITIUM_CLUSTER_ENDPOINT envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export INITIUM_REGISTRY_USER="<github_user>"
 and
 
 ```
-export INITIUM_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-k8s-kurated-addons")].cluster.server}')
+export INITIUM_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-initium-platform")].cluster.server}')
 export INITIUM_CLUSTER_TOKEN=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.token}" | base64 -d)
 export INITIUM_CLUSTER_CA_CERT=$(kubectl get secrets initium-cli-token -o jsonpath="{.data.ca\.crt}" | base64 -d)
 ```


### PR DESCRIPTION
The command for generating the `INITIUM_CLUSTER_ENDPOINT` envvar doesn't work because there was a change in the default name for Initium clusters.