### PR TITLE
fix: release-please and pipeline templates

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -34,7 +34,7 @@ jobs:
         run: go run main.go build
         env:
           INITIUM_APP_NAME: initium-cli
-          INITIUM_VERSION: ${{ steps.release.outputs.release_tag_name }}
+          INITIUM_VERSION: ${{ steps.release.outputs.tag_name }}
           INITIUM_REGISTRY_USER: ${{ github.actor }}
           INITIUM_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
@@ -43,7 +43,7 @@ jobs:
         run: go run main.go push
         env:
           INITIUM_APP_NAME: initium-cli
-          INITIUM_VERSION: ${{ steps.release.outputs.release_tag_name }}
+          INITIUM_VERSION: ${{ steps.release.outputs.tag_name }}
           INITIUM_REGISTRY_USER: ${{ github.actor }}
           INITIUM_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}

--- a/assets/github/onbranch.tmpl
+++ b/assets/github/onbranch.tmpl
@@ -22,7 +22,7 @@ jobs:
           ref: {{ `${{ github.head_ref }}` }}
 
       - name: build and deploy application
-        uses: docker://ghcr.io/nearform/initium-cli:latest
+        uses: docker://ghcr.io/nearform/initium-cli:{{ .Version }}
         with:
           args: onbranch
         env:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
     
       - name: delete application
-        uses: docker://ghcr.io/nearform/initium-cli:latest
+        uses: docker://ghcr.io/nearform/initium-cli:{{ .Version }}
         with:
           args: onbranch --clean --branch-name {{ `${{ github.head_ref }}` }}
         env:

--- a/assets/github/onmain.tmpl
+++ b/assets/github/onmain.tmpl
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: build and deploy on {{ .DefaultBranch }}
-        uses: docker://ghcr.io/nearform/initium-cli:latest
+        uses: docker://ghcr.io/nearform/initium-cli:{{ .Version }}
         with:
           args: onmain
         env:

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -25,11 +25,19 @@ func (c icli) InitGithubCMD(cCtx *cli.Context) error {
 	logger := log.New(os.Stderr)
 	logger.SetLevel(log.DebugLevel)
 
+	version := "v" + c.release.Version // Go releaser strips the v, we want it back for containers
+
+	if c.release.Version == "dev" {
+		version = "latest"
+	}
+
 	options := project.InitOptions{
 		PipelineType:      cCtx.Command.Name,
 		DestinationFolder: cCtx.String(destinationFolderFlag),
 		DefaultBranch:     cCtx.String(defaultBranchFlag),
+		Version:           version,
 	}
+
 	data, err := project.ProjectInit(options, c.Resources)
 
 	if err != nil {

--- a/src/services/project/project.go
+++ b/src/services/project/project.go
@@ -35,6 +35,7 @@ type InitOptions struct {
 	DestinationFolder string
 	DefaultBranch     string
 	PipelineType      string
+	Version           string
 }
 
 func GuessAppName() *string {


### PR DESCRIPTION
I was using the wrong output key when building a container. Also we were always pointing generated pipelines to the latest container generated, with this change we will have a container version and we can use that when templating pipelines.